### PR TITLE
feat: caching optimization

### DIFF
--- a/api/src/main/java/run/halo/app/core/extension/Plugin.java
+++ b/api/src/main/java/run/halo/app/core/extension/Plugin.java
@@ -1,6 +1,7 @@
 package run.halo.app.core.extension;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static run.halo.app.core.extension.Plugin.KIND;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -27,10 +28,11 @@ import run.halo.app.infra.ConditionList;
  */
 @Data
 @ToString(callSuper = true)
-@GVK(group = "plugin.halo.run", version = "v1alpha1", kind = "Plugin", plural = "plugins",
+@GVK(group = "plugin.halo.run", version = "v1alpha1", kind = KIND, plural = "plugins",
     singular = "plugin")
 @EqualsAndHashCode(callSuper = true)
 public class Plugin extends AbstractExtension {
+    public static final String KIND = "Plugin";
 
     @Schema(requiredMode = REQUIRED)
     private PluginSpec spec;

--- a/application/src/main/java/run/halo/app/cache/CacheConditionProvider.java
+++ b/application/src/main/java/run/halo/app/cache/CacheConditionProvider.java
@@ -1,0 +1,100 @@
+package run.halo.app.cache;
+
+import java.util.Objects;
+import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+import run.halo.app.extension.ReactiveExtensionClientImpl;
+import run.halo.app.infra.properties.HaloProperties;
+
+/**
+ * Provides methods to determine if specific types of caches are evictable or enabled.
+ *
+ * <p>Uses {@link HaloProperties} to check the configuration for cache settings.
+ *
+ * @author sergei
+ * @see HaloProperties#getCaches()
+ * @see Cacheable#condition()
+ * @see CacheEvict#condition()
+ * @see ReactiveExtensionClientImpl
+ */
+@Component
+@RequiredArgsConstructor
+public class CacheConditionProvider {
+    private static final String ROLE_KIND = "Role";
+    private static final String PLUGIN_KIND = "Plugin";
+    private static final String EXTENSION_POINT_DEFINITION_KIND = "ExtensionPointDefinition";
+
+    private final HaloProperties properties;
+
+    /**
+     * Determines if the role dependencies cache is evictable based on the provided kind.
+     *
+     * @param kind the kind to check against.
+     * @return {@code true} if the role dependencies cache is evictable, {@code false} otherwise.
+     */
+    public boolean isRoleDependenciesCacheEvictableByKind(String kind) {
+        return isRoleCacheEnabled() && Objects.equals(kind, ROLE_KIND);
+    }
+
+    /**
+     * Determines if the plugin extension cache is evictable based on the provided kind.
+     *
+     * @param kind the kind to check against.
+     * @return {@code true} if the plugin extension cache is evictable, {@code false} otherwise.
+     */
+    public boolean isPluginExtensionCacheEvictableByKind(String kind) {
+        return isPluginExtensionCacheEnabled() && Objects.equals(kind, PLUGIN_KIND);
+    }
+
+    /**
+     * Determines if the extension point definition cache is evictable based on the provided kind.
+     *
+     * @param kind the kind to check against.
+     * @return {@code true} if the extension point definition cache is evictable, {@code false}
+     * otherwise.
+     */
+    public boolean isExtensionPointDefinitionCacheEvictableByKind(String kind) {
+        return isExtensionPointDefinitionCacheEnabled() && Objects.equals(kind,
+            EXTENSION_POINT_DEFINITION_KIND);
+    }
+
+    /**
+     * Checks if the role dependencies cache is enabled.
+     *
+     * @return {@code true} if the role dependencies cache is enabled, {@code false} otherwise
+     */
+    public boolean isRoleCacheEnabled() {
+        return isCacheEnabled("role-dependencies");
+    }
+
+    /**
+     * Checks if the plugin extension cache is enabled.
+     *
+     * @return {@code true} if the plugin extension cache is enabled, {@code false} otherwise.
+     */
+    public boolean isPluginExtensionCacheEnabled() {
+        return isCacheEnabled("plugin-extension");
+    }
+
+    /**
+     * Checks if the extension point definition cache is enabled.
+     *
+     * @return {@code true} if the extension point definition cache is enabled, {@code false}
+     * otherwise.
+     */
+    public boolean isExtensionPointDefinitionCacheEnabled() {
+        return isCacheEnabled("extension-point-definition");
+    }
+
+    private boolean isCacheEnabled(String cache) {
+        var cacheProperties = properties.getCaches().get(cache);
+
+        if (cacheProperties != null) {
+            return !cacheProperties.isDisabled();
+        }
+
+        return false;
+    }
+}

--- a/application/src/main/java/run/halo/app/cache/CacheConditionProvider.java
+++ b/application/src/main/java/run/halo/app/cache/CacheConditionProvider.java
@@ -5,8 +5,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Component;
+import run.halo.app.core.extension.Plugin;
+import run.halo.app.core.extension.Role;
 import run.halo.app.extension.ReactiveExtensionClientImpl;
 import run.halo.app.infra.properties.HaloProperties;
+import run.halo.app.plugin.extensionpoint.ExtensionPointDefinition;
 
 /**
  * Provides methods to determine if specific types of caches are evictable or enabled.
@@ -22,10 +25,6 @@ import run.halo.app.infra.properties.HaloProperties;
 @Component
 @RequiredArgsConstructor
 public class CacheConditionProvider {
-    private static final String ROLE_KIND = "Role";
-    private static final String PLUGIN_KIND = "Plugin";
-    private static final String EXTENSION_POINT_DEFINITION_KIND = "ExtensionPointDefinition";
-
     private final HaloProperties properties;
 
     /**
@@ -35,7 +34,7 @@ public class CacheConditionProvider {
      * @return {@code true} if the role dependencies cache is evictable, {@code false} otherwise.
      */
     public boolean isRoleDependenciesCacheEvictableByKind(String kind) {
-        return isRoleCacheEnabled() && Objects.equals(kind, ROLE_KIND);
+        return isRoleDependenciesCacheEnabled() && Objects.equals(kind, Role.KIND);
     }
 
     /**
@@ -45,7 +44,7 @@ public class CacheConditionProvider {
      * @return {@code true} if the plugin extension cache is evictable, {@code false} otherwise.
      */
     public boolean isPluginExtensionCacheEvictableByKind(String kind) {
-        return isPluginExtensionCacheEnabled() && Objects.equals(kind, PLUGIN_KIND);
+        return isPluginExtensionCacheEnabled() && Objects.equals(kind, Plugin.KIND);
     }
 
     /**
@@ -56,8 +55,8 @@ public class CacheConditionProvider {
      * otherwise.
      */
     public boolean isExtensionPointDefinitionCacheEvictableByKind(String kind) {
-        return isExtensionPointDefinitionCacheEnabled() && Objects.equals(kind,
-            EXTENSION_POINT_DEFINITION_KIND);
+        return isExtensionPointDefinitionCacheEnabled()
+            && Objects.equals(kind, ExtensionPointDefinition.KIND);
     }
 
     /**
@@ -65,7 +64,7 @@ public class CacheConditionProvider {
      *
      * @return {@code true} if the role dependencies cache is enabled, {@code false} otherwise
      */
-    public boolean isRoleCacheEnabled() {
+    public boolean isRoleDependenciesCacheEnabled() {
         return isCacheEnabled("role-dependencies");
     }
 

--- a/application/src/main/java/run/halo/app/cache/CacheNames.java
+++ b/application/src/main/java/run/halo/app/cache/CacheNames.java
@@ -1,0 +1,41 @@
+package run.halo.app.cache;
+
+import java.util.Set;
+import run.halo.app.core.extension.service.DefaultRoleService;
+import run.halo.app.extension.ReactiveExtensionClientImpl;
+import run.halo.app.plugin.extensionpoint.DefaultExtensionGetter;
+
+/**
+ * Defines constant cache names used in the application.
+ *
+ * @author sergei
+ */
+public final class CacheNames {
+
+    /**
+     * Cache name for dependencies roles.
+     *
+     * @see DefaultRoleService#listDependenciesFlux(Set)
+     * @see ReactiveExtensionClientImpl
+     */
+    public static final String ROLE_DEPENDENCIES = "ROLE_DEPENDENCIES";
+
+    /**
+     * Cache name for plugin extensions.
+     *
+     * @see DefaultExtensionGetter#getExtensions(Class)
+     * @see ReactiveExtensionClientImpl
+     */
+    public static final String PLUGIN_EXTENSIONS = "PLUGIN_EXTENSIONS";
+
+    /**
+     * Cache name for plugin extensions.
+     *
+     * @see DefaultExtensionGetter#getEnabledExtensionByDefinition(Class)
+     * @see ReactiveExtensionClientImpl
+     */
+    public static final String EXTENSION_POINT_DEFINITIONS = "EXTENSION_POINT_DEFINITIONS";
+
+    private CacheNames() {
+    }
+}

--- a/application/src/main/java/run/halo/app/config/postproccessor/CaffeineCacheManagerPostProcessor.java
+++ b/application/src/main/java/run/halo/app/config/postproccessor/CaffeineCacheManagerPostProcessor.java
@@ -1,0 +1,32 @@
+package run.halo.app.config.postproccessor;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.cache.caffeine.CaffeineCacheManager;
+import org.springframework.lang.NonNull;
+import org.springframework.stereotype.Component;
+
+/**
+ * Post-processes of {@link CaffeineCacheManager} beans to enabled async mode for them after
+ * initialization.
+ *
+ * @author sergei
+ * @see CaffeineCacheManager#setAsyncCacheMode(boolean)
+ */
+@Component
+public class CaffeineCacheManagerPostProcessor implements BeanPostProcessor {
+
+    @Override
+    public Object postProcessAfterInitialization(@NonNull Object bean, @NonNull String beanName)
+        throws BeansException {
+        if (bean instanceof CaffeineCacheManager cacheManager) {
+            configure(cacheManager);
+        }
+
+        return BeanPostProcessor.super.postProcessAfterInitialization(bean, beanName);
+    }
+
+    private void configure(CaffeineCacheManager caffeineCacheManager) {
+        caffeineCacheManager.setAsyncCacheMode(true);
+    }
+}

--- a/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
@@ -76,7 +76,7 @@ public class DefaultRoleService implements RoleService {
     @Override
     @Cacheable(
         value = CacheNames.ROLE_DEPENDENCIES,
-        condition = "@cacheConditionProvider.isRoleCacheEnabled()"
+        condition = "@cacheConditionProvider.isRoleDependenciesCacheEnabled()"
     )
     public Flux<Role> listDependenciesFlux(Set<String> names) {
         return listDependencies(names, shouldFilterHidden(false));

--- a/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
+++ b/application/src/main/java/run/halo/app/core/extension/service/DefaultRoleService.java
@@ -13,11 +13,13 @@ import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.cache.CacheNames;
 import run.halo.app.core.extension.Role;
 import run.halo.app.core.extension.RoleBinding;
 import run.halo.app.core.extension.RoleBinding.RoleRef;
@@ -72,6 +74,10 @@ public class DefaultRoleService implements RoleService {
     }
 
     @Override
+    @Cacheable(
+        value = CacheNames.ROLE_DEPENDENCIES,
+        condition = "@cacheConditionProvider.isRoleCacheEnabled()"
+    )
     public Flux<Role> listDependenciesFlux(Set<String> names) {
         return listDependencies(names, shouldFilterHidden(false));
     }

--- a/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
+++ b/application/src/main/java/run/halo/app/extension/ReactiveExtensionClientImpl.java
@@ -18,6 +18,8 @@ import java.util.function.Predicate;
 import lombok.NonNull;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Caching;
 import org.springframework.context.event.ContextRefreshedEvent;
 import org.springframework.context.event.EventListener;
 import org.springframework.dao.DataIntegrityViolationException;
@@ -29,6 +31,7 @@ import org.springframework.transaction.reactive.TransactionalOperator;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.util.retry.Retry;
+import run.halo.app.cache.CacheNames;
 import run.halo.app.extension.exception.ExtensionNotFoundException;
 import run.halo.app.extension.index.DefaultExtensionIterator;
 import run.halo.app.extension.index.ExtensionIterator;
@@ -170,6 +173,24 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(
+            value = CacheNames.ROLE_DEPENDENCIES,
+            condition = "@cacheConditionProvider.isRoleDependenciesCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.PLUGIN_EXTENSIONS,
+            condition =
+                "@cacheConditionProvider.isPluginExtensionCacheEvictableByKind"
+                    + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.EXTENSION_POINT_DEFINITIONS,
+            condition = "@cacheConditionProvider.isExtensionPointDefinitionCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true)
+    })
     public <E extends Extension> Mono<E> create(E extension) {
         checkClientWritable(extension);
         return Mono.just(extension)
@@ -203,6 +224,24 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(
+            value = CacheNames.ROLE_DEPENDENCIES,
+            condition = "@cacheConditionProvider.isRoleDependenciesCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.PLUGIN_EXTENSIONS,
+            condition =
+                "@cacheConditionProvider.isPluginExtensionCacheEvictableByKind"
+                    + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.EXTENSION_POINT_DEFINITIONS,
+            condition = "@cacheConditionProvider.isExtensionPointDefinitionCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true)
+    })
     public <E extends Extension> Mono<E> update(E extension) {
         checkClientWritable(extension);
         // Refactor the atomic reference if we have a better solution.
@@ -245,6 +284,24 @@ public class ReactiveExtensionClientImpl implements ReactiveExtensionClient {
     }
 
     @Override
+    @Caching(evict = {
+        @CacheEvict(
+            value = CacheNames.ROLE_DEPENDENCIES,
+            condition = "@cacheConditionProvider.isRoleDependenciesCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.PLUGIN_EXTENSIONS,
+            condition =
+                "@cacheConditionProvider.isPluginExtensionCacheEvictableByKind"
+                    + "(#extension.kind)",
+            allEntries = true),
+        @CacheEvict(
+            value = CacheNames.EXTENSION_POINT_DEFINITIONS,
+            condition = "@cacheConditionProvider.isExtensionPointDefinitionCacheEvictableByKind"
+                + "(#extension.kind)",
+            allEntries = true)
+    })
     public <E extends Extension> Mono<E> delete(E extension) {
         checkClientWritable(extension);
         // set deletionTimestamp

--- a/application/src/main/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetter.java
+++ b/application/src/main/java/run/halo/app/plugin/extensionpoint/DefaultExtensionGetter.java
@@ -8,12 +8,14 @@ import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.pf4j.ExtensionPoint;
 import org.pf4j.PluginManager;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Component;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import run.halo.app.cache.CacheNames;
 import run.halo.app.extension.ReactiveExtensionClient;
 import run.halo.app.infra.SystemConfigurableEnvironmentFetcher;
 import run.halo.app.infra.SystemSetting.ExtensionPointEnabled;
@@ -72,6 +74,10 @@ public class DefaultExtensionGetter implements ExtensionGetter {
     }
 
     @Override
+    @Cacheable(
+        value = CacheNames.EXTENSION_POINT_DEFINITIONS,
+        condition = "@cacheConditionProvider.isExtensionPointDefinitionCacheEnabled()"
+    )
     public <T extends ExtensionPoint> Flux<T> getEnabledExtensionByDefinition(
         Class<T> extensionPoint) {
         return fetchExtensionPointDefinition(extensionPoint)
@@ -88,6 +94,10 @@ public class DefaultExtensionGetter implements ExtensionGetter {
     }
 
     @Override
+    @Cacheable(
+        value = CacheNames.PLUGIN_EXTENSIONS,
+        condition = "@cacheConditionProvider.isPluginExtensionCacheEnabled()"
+    )
     public <T extends ExtensionPoint> Flux<T> getExtensions(Class<T> extensionPointClass) {
         var extensions = new ArrayList<>(pluginManager.getExtensions(extensionPointClass));
         applicationContext.getBeanProvider(extensionPointClass)

--- a/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionPointDefinition.java
+++ b/application/src/main/java/run/halo/app/plugin/extensionpoint/ExtensionPointDefinition.java
@@ -1,6 +1,7 @@
 package run.halo.app.plugin.extensionpoint;
 
 import static io.swagger.v3.oas.annotations.media.Schema.RequiredMode.REQUIRED;
+import static run.halo.app.plugin.extensionpoint.ExtensionPointDefinition.KIND;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Data;
@@ -22,9 +23,10 @@ import run.halo.app.extension.GVK;
 @ToString(callSuper = true)
 @EqualsAndHashCode(callSuper = true)
 @GVK(group = "plugin.halo.run", version = "v1alpha1",
-    kind = "ExtensionPointDefinition", singular = "extensionpointdefinition",
+    kind = KIND, singular = "extensionpointdefinition",
     plural = "extensionpointdefinitions")
 public class ExtensionPointDefinition extends AbstractExtension {
+    public static final String KIND = "ExtensionPointDefinition";
 
     @Schema(requiredMode = REQUIRED)
     private ExtensionPointSpec spec;

--- a/application/src/main/resources/application.yaml
+++ b/application/src/main/resources/application.yaml
@@ -37,6 +37,13 @@ halo:
     page:
       # Disable page cache by default due to experimental feature
       disabled: true
+    role-dependencies:
+      disabled: ${ROLE_DEPENDENCIES_CACHE_DISABLED:true}
+    plugin-extension:
+      disabled: ${PLUGIN_EXTENSION_CACHE_DISABLED:true}
+    extension-point-definition:
+      disabled: ${EXTENSION_POINT_DEFINITION_CACHE_DISABLED:true}
+
   work-dir: ${user.home}/.halo2
   plugin:
     plugins-root: ${halo.work-dir}/plugins


### PR DESCRIPTION
## What type of PR is this?

* /kind feature
* /kind improvement
* /area core

## What this PR does / why we need it:

Each user request for information about the post led to additional requests for information about
ExtensionPointDefinition, Plugin, and Role. This caused a significant performance degradation. To address this, caching
has been implemented, resulting in a substantial performance improvement, as demonstrated by the graphs below.

### Caching disabled

When caching is disabled, each request directly hits the backend, causing increased load and slower performance over
time. The graph below illustrates the number of requests processed per second without caching:
![image](https://github.com/Lokuster/halo/assets/16577559/27b52f7f-515e-4d88-8bbb-f016b9b2a05c)

### Caching enabled

With caching enabled, repeated requests for the same information are served from the cache, significantly reducing the
backend load and improving performance. The graph below shows the number of requests processed per second with caching enabled:
![image](https://github.com/Lokuster/halo/assets/16577559/e29fca72-48b1-4e40-af39-42d80ae63de7)

The comparison clearly demonstrates that enabling caching reduces the number of backend requests and improves overall
system performance.

### Loading test properties

For loading test were used these properties:

1. Number of published posts - 1000
2. No Auth
3. Only reading one of posts
4. RPS:

| Start RPS | End RPS | Duration (sec) |
|-----------|---------|----------------|
| 350       | 450     | 5              |
| 450       | 500     | 5              |
| 500       | 550     | 5              |
| 550       | 600     | 5              |
| 600       | 650     | 5              |
| 650       | 700     | 5              |
| 700       | 900     | 5              |
| 900       | 1100    | 5              |
| 1100      | 1300    | 15             |
| 1300      | 2500    | 15             |
| 1100      | 1300    | 15             |
| 1300      | 2500    | 15             |
| 2500      | 3500    | 15             |
| 3500      | 5000    | 20             |
| 5000      | 7000    | 20             |

## Special notes for your reviewer:

Please pay attention to the correctness of clearing the cache when changing data in the class
`run.halo.app.extension.ReactiveExtensionClientImpl`

In particular, ensure that the `@CacheEvict` annotation is used appropriately to invalidate the cache entries when
relevant data changes occur.

## Does this PR introduce a user-facing change?

No.
